### PR TITLE
IRT-4619 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 group = 'com.github.figaf'
-version = '2.1-IRT-4663-rev2-SNAPSHOT'
+version = '2.1-IRT-4619-rev2-SNAPSHOT'
 
 ext {
     enableSnapshotsForDependencyResolutionAndPublishing = project.findProperty('enableSnapshots') ?: 'false'

--- a/src/main/java/com/figaf/integration/common/client/BaseClient.java
+++ b/src/main/java/com/figaf/integration/common/client/BaseClient.java
@@ -606,7 +606,7 @@ public class BaseClient {
         } catch (ClientIntegrationException ex) {
             throw ex;
         } catch (HttpClientErrorException.NotFound ex) {
-            throw new ClientIntegrationException(format("Can't execute GET %s successfully: %s", url, ex.getMessage()));
+            throw new ClientIntegrationException(format("Can't execute GET %s successfully: %s", url, ex.getMessage()), ex);
         } catch (Exception ex) {
             String errorMessage = format("Can't execute GET %s successfully: %s",
                 url, Utils.extractMessageAndRootCauseMessage(ex, false)


### PR DESCRIPTION
- propagated original cause in case of 404 for `executeGetRequestReturningTextBody`